### PR TITLE
Allow installing a package of the same version via APM

### DIFF
--- a/aurora_cli/src/api/group_api.py
+++ b/aurora_cli/src/api/group_api.py
@@ -52,11 +52,11 @@ help_routes = f'''
 {TextCommand.command_app_auth_check()}
 /app/auth/check
   • version - {TextArgument.argument_psdk_version()}
-  
+
 {TextCommand.command_app_auth_root()}
 /app/auth/root
   • password - {TextArgument.argument_password()}
-  
+
 -- /device --------------------------------------------------
 
 {TextCommand.command_device_list()}
@@ -75,25 +75,27 @@ help_routes = f'''
 /device/upload
   • host - {TextArgument.argument_host_device()}
   • path - {TextArgument.argument_path()}
-    
+
 {TextCommand.command_device_package_run()}
 /device/package/run
   • host - {TextArgument.argument_host_device()}
   • package - {TextArgument.argument_package_name()}
   • mode [dart, gdb] ({TextArgument.argument_optional()}) - {TextArgument.argument_run_mode()}
   • project ({TextArgument.argument_optional()}) - {TextArgument.argument_path_to_project()}
-    
+
 {TextCommand.command_device_package_install()}
 /device/package/install
   • host - {TextArgument.argument_host_device()}
   • path - {TextArgument.argument_path()}
   • apm [default = false, true] - {TextArgument.argument_apm()}
-    
+  • reinstall [default = false, true] - {TextArgument.argument_reinstall()}
+
 {TextCommand.command_device_package_remove()}
 /device/package/remove
   • host - {TextArgument.argument_host_device()}
   • package - {TextArgument.argument_package_name()}
   • apm [default = false, true] - {TextArgument.argument_apm()}
+  • keep_user_data [default = false, true] - {TextArgument.argument_keep_user_data()}
 
 -- /emulator -------------------------------------------------
 
@@ -119,22 +121,24 @@ help_routes = f'''
 {TextCommand.command_emulator_upload()}
 /emulator/upload
   • path - {TextArgument.argument_path()}
-    
+
 {TextCommand.command_emulator_package_run()}
 /emulator/package/run
   • package - {TextArgument.argument_package_name()}
   • mode [dart, gdb] ({TextArgument.argument_optional()}) - {TextArgument.argument_run_mode()}
   • project ({TextArgument.argument_optional()}) - {TextArgument.argument_path_to_project()}
-    
+
 {TextCommand.command_emulator_package_install()}
 /emulator/package/install
   • path - {TextArgument.argument_path()}
   • apm [default = false, true] - {TextArgument.argument_apm()}
-    
+  • reinstall [default = false, true] - {TextArgument.argument_reinstall()}
+
 {TextCommand.command_emulator_package_remove()}
 /emulator/package/remove
   • package - {TextArgument.argument_package_name()}
   • apm [default = false, true] - {TextArgument.argument_apm()}
+  • keep_user_data [default = false, true] - {TextArgument.argument_keep_user_data()}
 
 -- /flutter --------------------------------------------------
 
@@ -166,7 +170,7 @@ help_routes = f'''
 /flutter/project/icons
   • image - {TextArgument.argument_path_to_image()}
   • path - {TextArgument.argument_path_to_project()}
-  
+
 -- /psdk -----------------------------------------------------
 
 {TextCommand.command_psdk_available()}
@@ -253,15 +257,15 @@ help_routes = f'''
 
 {TextCommand.command_sdk_available()}
 /sdk/available
-  
+
 {TextCommand.command_sdk_installed()}
 /sdk/installed
-  
+
 {TextCommand.command_sdk_install()}
 /sdk/install
   • version - {TextArgument.argument_psdk_version()}
   • offline [default = false, true] - {TextArgument.argument_sdk_installer_type()}
-  
+
 {TextCommand.command_sdk_tool()}
 /sdk/tool
 
@@ -299,7 +303,7 @@ help_routes = f'''
 {TextCommand.command_settings_select()}
 /settings/select
   • enable [false, true] - {TextArgument.argument_enable_save_select()}
-  
+
 {TextCommand.command_settings_hint()}
 /settings/hint
   • enable [false, true] - {TextArgument.argument_enable_hint()}

--- a/aurora_cli/src/api/routes/routes_device.py
+++ b/aurora_cli/src/api/routes/routes_device.py
@@ -62,12 +62,14 @@ def search_route_device(route: str) -> bool:
         device_package_install_common(
             path=get_arg_str(route, 'path'),
             apm=get_arg_bool(route, 'apm'),
+            reinstall=get_arg_bool(route, 'reinstall'),
             model=DeviceModel.get_model_by_host(get_arg_str(route, 'host')),
         )
     elif root == '/device/package/remove':
         device_package_remove_common(
             package=get_arg_str(route, 'package'),
             apm=get_arg_bool(route, 'apm'),
+            keep_user_data=get_arg_bool(route, 'keep-user-data'),
             model=DeviceModel.get_model_by_host(get_arg_str(route, 'host')),
         )
     else:

--- a/aurora_cli/src/api/routes/routes_emulator.py
+++ b/aurora_cli/src/api/routes/routes_emulator.py
@@ -62,12 +62,14 @@ def search_route_emulator(route: str) -> bool:
             model=EmulatorModel.get_model_root(),
             path=get_arg_str(route, 'path'),
             apm=get_arg_bool(route, 'apm'),
+            reinstall=get_arg_bool(route, 'reinstall'),
         )
     elif root == '/emulator/package/remove':
         emulator_package_remove_common(
             model=EmulatorModel.get_model_root(),
             package=get_arg_str(route, 'package'),
             apm=get_arg_bool(route, 'apm'),
+            keep_user_data=get_arg_bool(route, 'keep-user-data'),
         )
     elif root == '/emulator/start':
         emulator_start_common(

--- a/aurora_cli/src/base/common/groups/common/ssh_commands.py
+++ b/aurora_cli/src/base/common/groups/common/ssh_commands.py
@@ -33,6 +33,7 @@ from aurora_cli.src.base.common.features.ssh_features import (
     ssh_rpm_install,
     ssh_package_remove,
     ssh_download,
+    ssh_check_package_installed,
 )
 from aurora_cli.src.base.configuration.app_config import AppConfig
 from aurora_cli.src.base.interface.model_client import ModelClient
@@ -249,6 +250,7 @@ def ssh_install_common(
         model: ModelClient,
         path: str,
         apm: bool,
+        reinstall: bool,
         devel_su: Any = None
 ):
     client = _get_ssh_client(model)
@@ -271,6 +273,7 @@ def ssh_install_common(
         client=client,
         path=path,
         apm=apm,
+        reinstall=reinstall,
         listen_progress=lambda stdout: state_update(bar, stdout.value),
         devel_su=devel_su
     )
@@ -284,6 +287,7 @@ def ssh_remove_common(
         model: ModelClient,
         package: str,
         apm: bool,
+        keep_user_data: bool,
         devel_su: Any = None
 ):
     client = _get_ssh_client(model)
@@ -292,6 +296,7 @@ def ssh_remove_common(
         client=client,
         package=package,
         apm=apm,
+        keep_user_data=keep_user_data,
         devel_su=devel_su
     ))
 
@@ -301,9 +306,8 @@ def ssh_check_package(
         package: str,
 ) -> bool:
     client = _get_ssh_client(model)
-    result = ssh_command(
+    return ssh_check_package_installed(
         client=client,
-        execute=f'ls /usr/bin/{package}'
+        package=package,
+        close=True,
     )
-    client.close()
-    return 'No such file or directory' not in result.value['stdout'][0]

--- a/aurora_cli/src/base/common/groups/device/device_package_features.py
+++ b/aurora_cli/src/base/common/groups/device/device_package_features.py
@@ -36,14 +36,16 @@ def device_package_install_common(
         model: DeviceModel,
         path: str,
         apm: bool,
-): ssh_install_common(model, path, apm, model.devel_su)
+        reinstall: bool
+): ssh_install_common(model, path, apm, reinstall, model.devel_su)
 
 
 def device_package_remove_common(
         model: DeviceModel,
         package: str,
         apm: bool,
-): ssh_remove_common(model, package, apm)
+        keep_user_data: bool,
+): ssh_remove_common(model, package, apm, keep_user_data)
 
 
 def device_check_package_common(

--- a/aurora_cli/src/base/common/groups/emulator/emulator_package_features.py
+++ b/aurora_cli/src/base/common/groups/emulator/emulator_package_features.py
@@ -38,18 +38,20 @@ def emulator_package_install_common(
         model: EmulatorModel,
         path: str,
         apm: bool,
+        reinstall: bool
 ):
     emulator_tool_check_is_not_run(model)
-    ssh_install_common(model, path, apm)
+    ssh_install_common(model, path, apm, reinstall)
 
 
 def emulator_package_remove_common(
         model: EmulatorModel,
         package: str,
         apm: bool,
+        keep_user_data: bool,
 ):
     emulator_tool_check_is_not_run(model)
-    ssh_remove_common(model, package, apm)
+    ssh_remove_common(model, package, apm, keep_user_data)
 
 
 def emulator_check_package_common(

--- a/aurora_cli/src/base/localization/ru/ru_app_argument.py
+++ b/aurora_cli/src/base/localization/ru/ru_app_argument.py
@@ -71,6 +71,14 @@ class TextArgumentRu(Enum):
         return 'Использовать APM.'
 
     @staticmethod
+    def argument_reinstall():
+        return 'Переустановить пакет, если он уже установлен.'
+
+    @staticmethod
+    def argument_keep_user_data():
+        return 'Сохранить пользовательские данные.'
+
+    @staticmethod
     def argument_sdk_installer_type():
         return 'Загрузите установщик offline типа.'
 

--- a/aurora_cli/src/base/localization/ru/ru_info.py
+++ b/aurora_cli/src/base/localization/ru/ru_info.py
@@ -307,3 +307,11 @@ class TextInfoRu(Enum):
     @staticmethod
     def settings_item_empty():
         return 'Значение не установлено.'
+
+    @staticmethod
+    def removing_package_keeping_user_data(package: str):
+        return f'<blue>Удаление пакета</blue> {package} <blue>с сохранением пользовательских данных...</blue>'
+
+    @staticmethod
+    def package_removed_without_keeping_user_data(package: str, package_manager: str):
+        return f'<blue>Пакет</blue> {package} <blue>был удален через {package_manager} без сохранения пользовательских данных</blue> (сохранение пользовательских данных не поддерживается)'

--- a/aurora_cli/src/base/texts/app_argument.py
+++ b/aurora_cli/src/base/texts/app_argument.py
@@ -87,6 +87,16 @@ class TextArgument(Enum):
 
     @staticmethod
     @localization
+    def argument_reinstall():
+        return 'Reinstall an already installed package.'
+
+    @staticmethod
+    @localization
+    def argument_keep_user_data():
+        return 'Keep user data.'
+
+    @staticmethod
+    @localization
     def argument_sdk_installer_type():
         return 'Download offline type installer.'
 

--- a/aurora_cli/src/base/texts/info.py
+++ b/aurora_cli/src/base/texts/info.py
@@ -376,3 +376,13 @@ class TextInfo(Enum):
     @localization
     def settings_item_empty():
         return 'Value not set.'
+
+    @staticmethod
+    @localization
+    def removing_package_keeping_user_data(package: str):
+        return f'<blue>Removing the</blue> {package} <blue>package keeping used data...</blue>'
+
+    @staticmethod
+    @localization
+    def package_removed_without_keeping_user_data(package: str, package_manager: str):
+        return f'<blue>The</blue> {package} <blue>package removed via {package_manager} without keeping user data</blue> (keeping user data is not supported)'

--- a/aurora_cli/src/cli/device/subgroup_device_package.py
+++ b/aurora_cli/src/cli/device/subgroup_device_package.py
@@ -60,34 +60,38 @@ def package_run(
 @subgroup_device_package.command(name='install', help=TextCommand.command_device_package_install())
 @click.option('-p', '--path', type=click.STRING, required=True, help=TextArgument.argument_path_rpm())
 @click.option('-a', '--apm', is_flag=True, help=TextArgument.argument_apm())
+@click.option('-r', '--reinstall', is_flag=True, help=TextArgument.argument_reinstall())
 @click.option('-s', '--select', is_flag=True, help=TextArgument.argument_select())
 @click.option('-i', '--index', type=click.INT, help=TextArgument.argument_index())
 @click.option('-v', '--verbose', is_flag=True, help=TextArgument.argument_verbose())
 def package_install(
         path: str,
         apm: bool,
+        reinstall: bool,
         select: bool,
         index: int,
         verbose: bool
 ):
     model = cli_device_tool_select_model(select, index)
-    device_package_install_common(model, path, apm)
+    device_package_install_common(model, path, apm, reinstall)
     echo_verbose(verbose)
 
 
 @subgroup_device_package.command(name='remove', help=TextCommand.command_device_package_remove())
 @click.option('-p', '--package', type=click.STRING, required=True, help=TextArgument.argument_package_name())
 @click.option('-a', '--apm', is_flag=True, help=TextArgument.argument_apm())
+@click.option('-k', '--keep-user-data', is_flag=True, help=TextArgument.argument_keep_user_data())
 @click.option('-s', '--select', is_flag=True, help=TextArgument.argument_select())
 @click.option('-i', '--index', type=click.INT, help=TextArgument.argument_index())
 @click.option('-v', '--verbose', is_flag=True, help=TextArgument.argument_verbose())
 def package_remove(
         package: str,
         apm: bool,
+        keep_user_data: bool,
         select: bool,
         index: int,
         verbose: bool
 ):
     model = cli_device_tool_select_model(select, index)
-    device_package_remove_common(model, package, apm)
+    device_package_remove_common(model, package, apm, keep_user_data)
     echo_verbose(verbose)

--- a/aurora_cli/src/cli/emulator/subgroup_emulator_package.py
+++ b/aurora_cli/src/cli/emulator/subgroup_emulator_package.py
@@ -56,26 +56,30 @@ def package_run(
 @subgroup_emulator_package.command(name='install', help=TextCommand.command_emulator_package_install())
 @click.option('-p', '--path', type=click.STRING, required=True, help=TextArgument.argument_path_rpm())
 @click.option('-a', '--apm', is_flag=True, help=TextArgument.argument_apm())
+@click.option('-r', '--reinstall', is_flag=True, help=TextArgument.argument_reinstall())
 @click.option('-v', '--verbose', is_flag=True, help=TextArgument.argument_verbose())
 def package_install(
         path: str,
         apm: bool,
+        reinstall: bool,
         verbose: bool
 ):
     model = cli_emulator_tool_select_model(is_root=True)
-    emulator_package_install_common(model, path, apm)
+    emulator_package_install_common(model, path, apm, reinstall)
     echo_verbose(verbose)
 
 
 @subgroup_emulator_package.command(name='remove', help=TextCommand.command_emulator_package_remove())
 @click.option('-p', '--package', type=click.STRING, required=True, help=TextArgument.argument_package_name())
 @click.option('-a', '--apm', is_flag=True, help=TextArgument.argument_apm())
+@click.option('-k', '--keep-user-data', is_flag=True, help=TextArgument.argument_keep_user_data())
 @click.option('-v', '--verbose', is_flag=True, help=TextArgument.argument_verbose())
 def package_remove(
         package: str,
         apm: bool,
+        keep_user_data: bool,
         verbose: bool
 ):
     model = cli_emulator_tool_select_model(is_root=True)
-    emulator_package_remove_common(model, package, apm)
+    emulator_package_remove_common(model, package, apm, keep_user_data)
     echo_verbose(verbose)


### PR DESCRIPTION
If a package with the same version is already installed on the device, APM will return a `DowngradeAttempt` error.
Therefore, try to remove the package from the device with saving the application data.