### PR TITLE
Remove `if __name__ == '__main__'` from `__main__.py`

### DIFF
--- a/aurora_cli/__main__.py
+++ b/aurora_cli/__main__.py
@@ -95,5 +95,4 @@ app_help_handler(lambda out: localization_app(out))
 # Catch abort
 app_abort_handler(lambda: localization_abort(is_exit=True))
 
-if __name__ == '__main__':
-    main()
+main()


### PR DESCRIPTION
From python [docs](https://docs.python.org/3/library/__main__.html#id1):

> The content of `__main__.py` typically isn’t fenced with an `if __name__ == '__main__'` block. Instead, those files are kept short and import functions to execute from other modules. Those other modules can then be easily unit-tested and are properly reusable.